### PR TITLE
Add Vapor server scaffold

### DIFF
--- a/KalvianRootsServer/Package.swift
+++ b/KalvianRootsServer/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "KalvianRootsServer",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "Run", targets: ["Run"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.90.0")
+    ],
+    targets: [
+        .target(name: "App",
+                dependencies: [
+                    .product(name: "Vapor", package: "vapor")
+                ],
+                path: "Sources/App"),
+        .executableTarget(name: "Run",
+                          dependencies: ["App"],
+                          path: "Sources/Run"),
+        .testTarget(name: "AppTests",
+                    dependencies: ["App"],
+                    path: "Tests/AppTests")
+    ]
+)

--- a/KalvianRootsServer/Public/index.html
+++ b/KalvianRootsServer/Public/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8" /><title>Kalvian Roots SPA</title></head>
+  <body>
+    <h1>Kalvian Roots Browser UI</h1>
+    <p>Server scaffold is running.</p>
+  </body>
+</html>

--- a/KalvianRootsServer/Sources/App/configure.swift
+++ b/KalvianRootsServer/Sources/App/configure.swift
@@ -1,0 +1,21 @@
+import Vapor
+
+public func configure(_ app: Application) throws {
+    // Localhost binding
+    app.http.server.configuration.hostname = "127.0.0.1"
+    app.http.server.configuration.port = 8081
+
+    // Middlewares
+    app.middleware.use(RequestIDMiddleware())
+    app.middleware.use(ErrorEnvelopeMiddleware())
+
+    // Token for /api/* routes
+    let token = Environment.get("KALVIAN_API_TOKEN") ?? ""
+    let api = app.grouped("api").grouped(TokenAuthMiddleware(expectedToken: token))
+
+    // Shared in-memory stores
+    app.storage[InMemoryJobStore.Key.self] = InMemoryJobStore()
+    app.storage[InMemoryLockStore.Key.self] = InMemoryLockStore()
+
+    try routes(app, apiGroup: api)
+}

--- a/KalvianRootsServer/Sources/App/jobs/InMemoryJobStore.swift
+++ b/KalvianRootsServer/Sources/App/jobs/InMemoryJobStore.swift
@@ -1,0 +1,30 @@
+import Vapor
+
+actor InMemoryJobStore {
+    struct Key: StorageKey { typealias Value = InMemoryJobStore }
+
+    private var jobs: [UUID: JobState] = [:]
+
+    func create(type: String) -> JobState {
+        let now = Date()
+        let job = JobState(
+            id: UUID(),
+            type: type,
+            status: .queued,
+            createdAt: now,
+            updatedAt: now
+        )
+        jobs[job.id] = job
+        return job
+    }
+
+    func update(id: UUID, mutate: (inout JobState) -> Void) -> JobState? {
+        guard var job = jobs[id] else { return nil }
+        mutate(&job)
+        job.updatedAt = Date()
+        jobs[id] = job
+        return job
+    }
+
+    func get(id: UUID) -> JobState? { jobs[id] }
+}

--- a/KalvianRootsServer/Sources/App/jobs/JobState.swift
+++ b/KalvianRootsServer/Sources/App/jobs/JobState.swift
@@ -1,0 +1,15 @@
+import Vapor
+
+struct JobState: Content {
+    enum Status: String, Codable { case queued, running, completed, failed }
+    var id: UUID
+    var type: String
+    var status: Status
+    var createdAt: Date
+    var updatedAt: Date
+    var progress: Double?
+    var message: String?
+    var resultJSON: String?
+    var errorCode: String?
+    var errorMessage: String?
+}

--- a/KalvianRootsServer/Sources/App/locks/FamilyLock.swift
+++ b/KalvianRootsServer/Sources/App/locks/FamilyLock.swift
@@ -1,0 +1,9 @@
+import Vapor
+
+struct FamilyLock: Content {
+    var leaseId: UUID
+    var familyId: String
+    var owner: String?
+    var purpose: String?
+    var expiresAt: Date
+}

--- a/KalvianRootsServer/Sources/App/locks/InMemoryLockStore.swift
+++ b/KalvianRootsServer/Sources/App/locks/InMemoryLockStore.swift
@@ -1,0 +1,36 @@
+import Vapor
+
+actor InMemoryLockStore {
+    struct Key: StorageKey { typealias Value = InMemoryLockStore }
+
+    private var locks: [String: FamilyLock] = [:]
+
+    func acquire(familyId: String, owner: String?, purpose: String?, ttl: TimeInterval) -> FamilyLock? {
+        let now = Date()
+        if let existing = locks[familyId], existing.expiresAt > now { return nil }
+        let lock = FamilyLock(
+            leaseId: UUID(),
+            familyId: familyId,
+            owner: owner,
+            purpose: purpose,
+            expiresAt: now.addingTimeInterval(ttl)
+        )
+        locks[familyId] = lock
+        return lock
+    }
+
+    func heartbeat(leaseId: UUID, ttl: TimeInterval) -> FamilyLock? {
+        let now = Date()
+        guard let (fid, lock) = locks.first(where: { $0.value.leaseId == leaseId }) else { return nil }
+        var updated = lock
+        updated.expiresAt = now.addingTimeInterval(ttl)
+        locks[fid] = updated
+        return updated
+    }
+
+    func release(leaseId: UUID) {
+        if let fid = locks.first(where: { $0.value.leaseId == leaseId })?.key {
+            locks.removeValue(forKey: fid)
+        }
+    }
+}

--- a/KalvianRootsServer/Sources/App/middleware/ErrorEnvelopeMiddleware.swift
+++ b/KalvianRootsServer/Sources/App/middleware/ErrorEnvelopeMiddleware.swift
@@ -1,0 +1,28 @@
+import Vapor
+
+struct ErrorEnvelopeMiddleware: Middleware {
+    func respond(to req: Request, chainingTo next: Responder) async throws -> Response {
+        do { return try await next.respond(to: req) }
+        catch let abort as AbortError {
+            let env = ErrorEnvelope.make(code: abort.reason, message: abort.reason)
+            let res = Response(status: abort.status)
+            try res.content.encode(env)
+            return res
+        }
+        catch {
+            req.logger.report(error: error)
+            let env = ErrorEnvelope.make(code: "internal_error", message: "Unexpected error.")
+            let res = Response(status: .internalServerError)
+            try res.content.encode(env)
+            return res
+        }
+    }
+}
+
+struct ErrorEnvelope: Content {
+    struct Err: Content { let code: String; let message: String }
+    let error: Err
+    static func make(code: String, message: String) -> ErrorEnvelope {
+        .init(error: .init(code: code, message: message))
+    }
+}

--- a/KalvianRootsServer/Sources/App/middleware/RequestIDMiddleware.swift
+++ b/KalvianRootsServer/Sources/App/middleware/RequestIDMiddleware.swift
@@ -1,0 +1,15 @@
+import Vapor
+
+struct RequestIDMiddleware: Middleware {
+    private let key = "X-Request-Id"
+
+    func respond(to req: Request, chainingTo next: Responder) async throws -> Response {
+        let id = req.headers.first(name: key) ?? UUID().uuidString
+        req.headers.replaceOrAdd(name: key, value: id)
+        req.logger[metadataKey: "request_id"] = .string(id)
+
+        let res = try await next.respond(to: req)
+        res.headers.replaceOrAdd(name: key, value: id)
+        return res
+    }
+}

--- a/KalvianRootsServer/Sources/App/middleware/TokenAuthMiddleware.swift
+++ b/KalvianRootsServer/Sources/App/middleware/TokenAuthMiddleware.swift
@@ -1,0 +1,19 @@
+import Vapor
+
+struct TokenAuthMiddleware: Middleware {
+    let expectedToken: String
+
+    func respond(to req: Request, chainingTo next: Responder) async throws -> Response {
+        guard !expectedToken.isEmpty else { return try await next.respond(to: req) }
+
+        let provided = req.headers.bearerAuthorization?.token ?? ""
+        guard provided == expectedToken else {
+            let env = ErrorEnvelope.make(code: "unauthorized", message: "Invalid or missing token.")
+            let res = Response(status: .unauthorized)
+            try res.content.encode(env)
+            return res
+        }
+
+        return try await next.respond(to: req)
+    }
+}

--- a/KalvianRootsServer/Sources/App/routes.swift
+++ b/KalvianRootsServer/Sources/App/routes.swift
@@ -1,0 +1,58 @@
+import Vapor
+
+public func routes(_ app: Application, apiGroup: RoutesBuilder) throws {
+
+    // Public
+    app.get("health") { _ async -> [String:String] in
+        ["status": "ok"]
+    }
+
+    app.get("status") { req async -> StatusResponse in
+        StatusResponse(
+            status: "ok",
+            build: Environment.get("KALVIAN_BUILD") ?? "dev",
+            commit: Environment.get("KALVIAN_COMMIT") ?? "local",
+            uptimeSeconds: Int(ProcessInfo.processInfo.systemUptime)
+        )
+    }
+
+    // Jobs
+    let jobs = apiGroup.grouped("jobs")
+
+    jobs.post("extraction") { req async throws -> JobState in
+        let store = req.application.storage[InMemoryJobStore.Key.self]!
+        let job = await store.create(type: "extraction")
+
+        // placeholder async task
+        Task.detached {
+            await store.update(id: job.id) { $0.status = .running }
+            // TODO integrate Core + MLX
+            await store.update(id: job.id) { state in
+                state.status = .completed
+                state.progress = 1.0
+                state.message = "Extraction completed"
+            }
+        }
+
+        return job
+    }
+
+    jobs.get(":id") { req async throws -> JobState in
+        let store = req.application.storage[InMemoryJobStore.Key.self]!
+        guard
+            let idString = req.parameters.get("id"),
+            let uuid = UUID(uuidString: idString),
+            let job = await store.get(id: uuid)
+        else {
+            throw Abort(.notFound, reason: "Job not found")
+        }
+        return job
+    }
+}
+
+struct StatusResponse: Content {
+    let status: String
+    let build: String
+    let commit: String
+    let uptimeSeconds: Int
+}

--- a/KalvianRootsServer/Sources/Run/main.swift
+++ b/KalvianRootsServer/Sources/Run/main.swift
@@ -1,0 +1,16 @@
+import App
+import Vapor
+
+@main
+struct Run {
+    static func main() throws {
+        var env = try Environment.detect()
+        try LoggingSystem.bootstrap(from: &env)
+
+        let app = Application(env)
+        defer { app.shutdown() }
+
+        try configure(app)
+        try app.run()
+    }
+}


### PR DESCRIPTION
## Summary
- add Vapor server package scaffold with routes, middleware, and in-memory job/lock stores
- configure server to bind on localhost:8081 with bearer token protection for /api routes
- include placeholder public SPA index page

## Testing
- swift build *(fails: network access to fetch Vapor dependency blocked in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ff11405788324bfda943f9dcd2ac8)