### PR TITLE
Add browser UI for family lookup

### DIFF
--- a/KalvianRootsServer/Public/index.html
+++ b/KalvianRootsServer/Public/index.html
@@ -1,8 +1,149 @@
 <!DOCTYPE html>
 <html>
-  <head><meta charset="utf-8" /><title>Kalvian Roots SPA</title></head>
+  <head>
+    <meta charset="utf-8" />
+    <title>Kalvian Roots SPA</title>
+    <style>
+      body {
+        font-family: "Helvetica Neue", Arial, sans-serif;
+        max-width: 900px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #f7fafc;
+        color: #1f2937;
+      }
+
+      h1 {
+        margin-bottom: 0.25rem;
+      }
+
+      p.subtitle {
+        color: #4b5563;
+        margin-top: 0;
+      }
+
+      .card {
+        background: #fff;
+        border-radius: 10px;
+        padding: 1.25rem;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+        border: 1px solid #e5e7eb;
+      }
+
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+
+      .input-row {
+        display: flex;
+        gap: 0.75rem;
+      }
+
+      input[type="text"] {
+        flex: 1;
+        padding: 0.75rem;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 1rem;
+      }
+
+      button {
+        padding: 0.75rem 1.25rem;
+        border: none;
+        border-radius: 8px;
+        background: #2563eb;
+        color: #fff;
+        font-size: 1rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      button:hover {
+        background: #1d4ed8;
+      }
+
+      button:disabled {
+        background: #9ca3af;
+        cursor: not-allowed;
+      }
+
+      pre {
+        white-space: pre-wrap;
+        background: #0b1728;
+        color: #e5e7eb;
+        padding: 1rem;
+        border-radius: 8px;
+        min-height: 200px;
+        border: 1px solid #0f172a;
+        box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+      }
+
+      .status {
+        margin-top: 0.75rem;
+        color: #374151;
+        min-height: 1.5rem;
+      }
+    </style>
+  </head>
   <body>
     <h1>Kalvian Roots Browser UI</h1>
-    <p>Server scaffold is running.</p>
+    <p class="subtitle">Look up a family directly from the ROOTS_FILE.</p>
+
+    <div class="card">
+      <label for="familyId">Family ID</label>
+      <div class="input-row">
+        <input id="familyId" type="text" placeholder="e.g. HERLEVI 6" />
+        <button id="lookupBtn" type="button">Find Family</button>
+      </div>
+      <div class="status" id="status"></div>
+      <pre id="result">Enter a Family ID and click "Find Family" to see the record.</pre>
+    </div>
+
+    <script>
+      const familyInput = document.getElementById('familyId');
+      const lookupBtn = document.getElementById('lookupBtn');
+      const statusEl = document.getElementById('status');
+      const resultEl = document.getElementById('result');
+
+      async function fetchFamily() {
+        const id = familyInput.value.trim();
+        if (!id) {
+          statusEl.textContent = 'Please enter a Family ID.';
+          return;
+        }
+
+        lookupBtn.disabled = true;
+        statusEl.textContent = 'Searching…';
+        resultEl.textContent = '';
+
+        try {
+          const resp = await fetch(`/api/families/${encodeURIComponent(id)}`);
+          const payload = await resp.json();
+
+          if (!resp.ok) {
+            const message = payload.error?.message || 'Request failed';
+            throw new Error(message);
+          }
+
+          statusEl.textContent = `Showing family "${id}"`;
+          resultEl.textContent = payload.text;
+        } catch (err) {
+          statusEl.textContent = err.message;
+          resultEl.textContent = '';
+        } finally {
+          lookupBtn.disabled = false;
+        }
+      }
+
+      lookupBtn.addEventListener('click', fetchFamily);
+      familyInput.addEventListener('keyup', (event) => {
+        if (event.key === 'Enter') {
+          fetchFamily();
+        }
+      });
+    </script>
   </body>
 </html>

--- a/KalvianRootsServer/Sources/App/RootsFamilyLookupService.swift
+++ b/KalvianRootsServer/Sources/App/RootsFamilyLookupService.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Vapor
+
+struct RootsFamilyLookupService {
+    let app: Application
+
+    struct FamilyResponse: Content {
+        let id: String
+        let text: String
+    }
+
+    func findFamily(id: String) async throws -> FamilyResponse {
+        let trimmedID = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedID.isEmpty else {
+            throw Abort(.badRequest, reason: "Family ID is required.")
+        }
+
+        guard let rootsEnv = app.roots else {
+            throw Abort(.internalServerError, reason: "ROOTS_FILE is not configured on the server.")
+        }
+
+        let data = try Data(contentsOf: URL(fileURLWithPath: rootsEnv.rootsPath))
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw Abort(.internalServerError, reason: "Roots file is not valid UTF-8.")
+        }
+
+        let lowercasedNeedle = trimmedID.lowercased()
+        var block: [Substring] = []
+
+        func checkCurrentBlock() -> FamilyResponse? {
+            guard let header = block.first?.trimmingCharacters(in: .whitespaces) else { return nil }
+            if header.lowercased().hasPrefix(lowercasedNeedle) {
+                let blockText = block.joined(separator: "\n")
+                return FamilyResponse(id: trimmedID, text: blockText)
+            }
+            return nil
+        }
+
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+
+        for line in lines {
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                if let match = checkCurrentBlock() {
+                    return match
+                }
+                block.removeAll(keepingCapacity: true)
+            } else {
+                block.append(line)
+            }
+        }
+
+        if let match = checkCurrentBlock() {
+            return match
+        }
+
+        throw Abort(.notFound, reason: "Family \(trimmedID) not found.")
+    }
+}

--- a/KalvianRootsServer/Sources/App/routes.swift
+++ b/KalvianRootsServer/Sources/App/routes.swift
@@ -124,6 +124,18 @@ public func routes(_ app: Application, apiGroup: RoutesBuilder) throws {
             familyCount: nil // Will fill in later when Roots parser is integrated
         )
     }
+
+    // MARK: - Families
+
+    let families = apiGroup.grouped("families")
+    families.get(":id") { req async throws -> RootsFamilyLookupService.FamilyResponse in
+        guard let familyID = req.parameters.get("id") else {
+            throw Abort(.badRequest, reason: "Family ID is required.")
+        }
+
+        let service = RootsFamilyLookupService(app: req.application)
+        return try await service.findFamily(id: familyID)
+    }
 }
 
 // MARK: - Response Models


### PR DESCRIPTION
## Summary
- add a RootsFamilyLookupService that reads the ROOTS_FILE and returns the requested family text block
- expose a token-protected `/api/families/:id` endpoint that uses the lookup service
- replace the public index page with a family lookup form that fetches and displays family details

## Testing
- `swift test` *(fails: dependency fetch blocked by network/403 while cloning SwiftPM packages)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692266bd838c83249f79b6b200ee3de4)