### PR TITLE
Fix test compilation issues

### DIFF
--- a/Kalvian Roots/Utilities/DebugLogger.swift
+++ b/Kalvian Roots/Utilities/DebugLogger.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - LogLevel and LogCategory
 
-enum LogLevel: Int, CaseIterable {
+public enum LogLevel: Int, CaseIterable {
     case error = 0
     case warn = 1
     case info = 2
@@ -36,7 +36,7 @@ enum LogLevel: Int, CaseIterable {
     }
 }
 
-enum LogCategory: String, CaseIterable {
+public enum LogCategory: String, CaseIterable {
     case app = "APP"
     case ai = "AI"
     case parsing = "PARSE"
@@ -70,7 +70,7 @@ enum LogCategory: String, CaseIterable {
 
 // MARK: - DebugLogger Class
 
-class DebugLogger {
+public class DebugLogger {
     static let shared = DebugLogger()
     
     private var currentLevel: LogLevel = .debug
@@ -244,22 +244,22 @@ class DebugLogger {
 
 // MARK: - Global Convenience Functions
 
-func logError(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
+public func logError(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
     DebugLogger.shared.error(category, message, file: file, line: line)
 }
 
-func logWarn(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
+public func logWarn(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
     DebugLogger.shared.warn(category, message, file: file, line: line)
 }
 
-func logInfo(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
+public func logInfo(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
     DebugLogger.shared.info(category, message, file: file, line: line)
 }
 
-func logDebug(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
+public func logDebug(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
     DebugLogger.shared.debug(category, message, file: file, line: line)
 }
 
-func logTrace(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
+public func logTrace(_ category: LogCategory, _ message: String, file: String = #file, line: Int = #line) {
     DebugLogger.shared.trace(category, message, file: file, line: line)
 }

--- a/Kalvian RootsTests/UtilityClassesTests.swift
+++ b/Kalvian RootsTests/UtilityClassesTests.swift
@@ -14,14 +14,14 @@ final class NameEquivalenceManagerTests: XCTestCase {
     
     var manager: NameEquivalenceManager!
     
-    override func setUp() throws {
-        try super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         manager = NameEquivalenceManager()
     }
-    
-    override func tearDown() throws {
+
+    override func tearDownWithError() throws {
         manager = nil
-        try super.tearDown()
+        try super.tearDownWithError()
     }
     
     func testManagerInitialization() {
@@ -61,7 +61,7 @@ final class NameEquivalenceManagerTests: XCTestCase {
     
     func testAddCustomEquivalence() {
         // When: Adding custom equivalence
-        manager.addEquivalence("TestName1", "TestName2")
+        manager.addEquivalence(between: "TestName1", and: "TestName2")
         
         // Then: Should recognize equivalence
         XCTAssertTrue(manager.areNamesEquivalent("TestName1", "TestName2"))
@@ -69,11 +69,11 @@ final class NameEquivalenceManagerTests: XCTestCase {
     
     func testRemoveEquivalence() {
         // Given: Custom equivalence
-        manager.addEquivalence("TestName1", "TestName2")
+        manager.addEquivalence(between: "TestName1", and: "TestName2")
         XCTAssertTrue(manager.areNamesEquivalent("TestName1", "TestName2"))
-        
+
         // When: Removing equivalence
-        manager.removeEquivalence("TestName1", "TestName2")
+        manager.removeEquivalence(between: "TestName1", and: "TestName2")
         
         // Then: Should no longer be equivalent
         XCTAssertFalse(manager.areNamesEquivalent("TestName1", "TestName2"))
@@ -100,16 +100,16 @@ final class HiskiServiceTests: XCTestCase {
     var service: HiskiService!
     var nameEquivalenceManager: NameEquivalenceManager!
     
-    override func setUp() throws {
-        try super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         nameEquivalenceManager = NameEquivalenceManager()
         service = HiskiService(nameEquivalenceManager: nameEquivalenceManager)
     }
-    
-    override func tearDown() throws {
+
+    override func tearDownWithError() throws {
         service = nil
         nameEquivalenceManager = nil
-        try super.tearDown()
+        try super.tearDownWithError()
     }
     
     func testServiceInitialization() {


### PR DESCRIPTION
## Summary
- expose logging enums and helper functions publicly so tests can call logDebug and logWarn
- update utility tests to use correct argument labels and XCTest throwing setup/teardown hooks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69408ea487588324a80756bb993e511c)