### PR TITLE
Add FamilyNetworkCaching protocol and make FamilyNetworkCache conform

### DIFF
--- a/Kalvian Roots/App/FamilyNetworkCache.swift
+++ b/Kalvian Roots/App/FamilyNetworkCache.swift
@@ -9,6 +9,13 @@
 
 import Foundation
 
+@MainActor
+protocol FamilyNetworkCaching: AnyObject {
+    func fetchNetwork(familyId: String) -> FamilyNetwork?
+    func storeNetwork(_ network: FamilyNetwork)
+    func invalidate(familyId: String)
+}
+
 /**
  * FamilyNetworkCache - Simple in-memory cache for now
  *
@@ -17,7 +24,7 @@ import Foundation
  */
 @Observable
 @MainActor
-class FamilyNetworkCache {
+class FamilyNetworkCache: FamilyNetworkCaching {
 
     // MARK: - Properties
 
@@ -90,6 +97,20 @@ class FamilyNetworkCache {
     }
     
     // MARK: - Public Methods
+
+    func fetchNetwork(familyId: String) -> FamilyNetwork? {
+        getCachedNetwork(familyId: familyId)
+    }
+
+    func storeNetwork(_ network: FamilyNetwork) {
+        let normalized = network.mainFamily.familyId.uppercased().trimmingCharacters(in: .whitespaces)
+        let extractionTime = cachedNetworks[normalized]?.extractionTime ?? 0
+        cacheNetwork(network, extractionTime: extractionTime)
+    }
+
+    func invalidate(familyId: String) {
+        deleteCachedFamily(familyId: familyId)
+    }
     
     /**
      * Check if a family is cached
@@ -620,4 +641,3 @@ class FamilyNetworkCache {
         )
     }
 }
-

--- a/Kalvian Roots/App/FamilyResolver.swift
+++ b/Kalvian Roots/App/FamilyResolver.swift
@@ -29,7 +29,7 @@ class FamilyResolver {
     private let fileManager: RootsFileManager
     private let nameEquivalenceManager: NameEquivalenceManager
     private let aiParsingService: AIParsingService
-    private weak var familyNetworkCache: FamilyNetworkCache?
+    private weak var familyNetworkCache: FamilyNetworkCaching?
 
     // Track resolution statistics
     private var resolutionStatistics = ResolutionStatistics()
@@ -39,7 +39,7 @@ class FamilyResolver {
     init(aiParsingService: AIParsingService,
          nameEquivalenceManager: NameEquivalenceManager,
          fileManager: RootsFileManager,
-         familyNetworkCache: FamilyNetworkCache? = nil) {
+         familyNetworkCache: FamilyNetworkCaching? = nil) {
         self.aiParsingService = aiParsingService
         self.nameEquivalenceManager = nameEquivalenceManager
         self.fileManager = fileManager
@@ -344,9 +344,9 @@ class FamilyResolver {
         
         // NEW: Check cache first to avoid redundant AI calls!
         if let cache = familyNetworkCache,
-           let cachedFamily = cache.getCachedNuclearFamily(familyId: cleanedRef) {
+           let cachedNetwork = cache.fetchNetwork(familyId: cleanedRef) {
             logInfo(.resolver, "⚡ Using cached family (avoiding AI call): \(cleanedRef)")
-            return cachedFamily
+            return cachedNetwork.mainFamily
         }
         
         // Cache miss - parse from file with AI


### PR DESCRIPTION
### Motivation

- Decouple consumers from the concrete cache implementation by introducing an abstraction for cache access and to hide implementation metadata such as `CachedFamily`, `cachedAt`, and `extractionTime` from public usage.
- Preserve existing cache behavior and storage format while enabling future testability and substitution of cache implementations.

### Description

- Added an `@MainActor` protocol `FamilyNetworkCaching` that exposes only `fetchNetwork(familyId:)`, `storeNetwork(_:)`, and `invalidate(familyId:)` as the public cache surface.
- Made `FamilyNetworkCache` conform to `FamilyNetworkCaching` and implemented forwarding methods that reuse the existing `getCachedNetwork`, `cacheNetwork`, and `deleteCachedFamily` logic without changing storage format or behavior.
- Updated `FamilyResolver` to accept and use a `FamilyNetworkCaching` reference instead of the concrete `FamilyNetworkCache`, and switched cache usage to call `fetchNetwork(...)` and return `mainFamily` where appropriate.
- Left `CachedFamily`, `cachedAt`, and `extractionTime` as internal details and did not change JSON schemas or any caching logic.

### Testing

- No automated tests were executed as part of this change.
- Local edits compile-time impact was not validated in this patch (no build/run performed by the change author).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c5fe2b5ec8324ba5088e7cd0bd3eb)